### PR TITLE
Use ember@1.13.8 as default ember

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-collection",
   "dependencies": {
-    "ember": "components/ember#canary",
+    "ember": "1.13.8",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
@@ -11,8 +11,5 @@
     "jquery": "^2.1.4",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"
-  },
-  "resolutions": {
-    "ember": "canary"
   }
 }


### PR DESCRIPTION
This PR ensures that we test with 1.13.8, stable, beta and canary (allowed to fail) in CI.
Note that when playing around in the dummy app you will be using 1.13.8.