### PR TITLE
Fix dummy app

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -143,6 +143,11 @@ export default Ember.Component.extend({
   //     this.rerender();
   //   }
   // },
+
+  willRender: function() {
+    this.notifyPropertyChange('cells');
+  },
+
   updateCells() {
     if (!this._items) { return; }
     if (this._cellLayout.length !== this._items.length) {
@@ -242,7 +247,7 @@ export default Ember.Component.extend({
   },
   calculateContentSize() {
     var cellLayout = this._cellLayout;
-    if (cellLayout == null || this._width == null || this._height == null) { return; }
+    if (cellLayout == null || this._width == null || this._height == null || this.contentElement === undefined) { return; }
     var contentWidth = cellLayout.contentWidth(this._width);
     var contentHeight = cellLayout.contentHeight(this._width);
     this.contentElement.style.width = contentWidth + 'px';

--- a/addon/layouts/grid.js
+++ b/addon/layouts/grid.js
@@ -16,8 +16,8 @@ export default class Grid
     return this.bin.height(width);
   }
 
-  indexAt(offsetX, offsetY, width /*,height*/) {
-    return this.bin.visibleStartingIndex(offsetY, width);
+  indexAt(offsetX, offsetY, width, height) {
+    return this.bin.visibleStartingIndex(offsetY, width, height);
   }
 
   positionAt(index, width /*,height*/) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "0.7.9",
-    "layout-bin-packer": "^1.0.2"
+    "layout-bin-packer": "^1.0.5"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This fixes an issue related to the update to `layout-bin-packer`causing
an `NaN` index when calculating the starting index. It invaldiates `cells` when
rendering. This is needed to cause the cells to update during scrolling.

Basically how this works now is `rAF` monitors the scroll position and
if the positions change between frames it schedules a `rerender`. The
`willRender` hook then invalidates the `cells` CP which ensures the
correct items are rendered. Then glimmer takes over and renders the
correct cells.

I also guarded `contentElement` not being defined on initial render.