### PR TITLE
Remove list item class

### DIFF
--- a/addon/components/ember-collection/template.hbs
+++ b/addon/components/ember-collection/template.hbs
@@ -1,5 +1,5 @@
 <div>
   {{~#each cells as |cell|~}}
-    <div class="ember-list-item-view" style={{{cell.style}}}>{{#unless cell.hidden}}{{yield cell.item cell.index }}{{/unless}}</div>
+    <div style={{{cell.style}}}>{{#unless cell.hidden}}{{yield cell.item cell.index }}{{/unless}}</div>
   {{~/each~}}
 </div>

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -8,6 +8,19 @@ function generateContent(n) {
   }
   return content;
 }
+
+function findContainer(context) {
+  return context.$('.ember-collection div:first');
+}
+
+function findItems(context) {
+  return context.$('.ember-collection div:first > div');
+}
+
+function findVisibleItems(context) {
+  return context.$('.ember-collection div:first > div:visible');
+}
+
 function extractPositionFromTransform(string) {
   var matched, x, y, position;
 
@@ -28,6 +41,7 @@ function extractNumberFromPosition(string) {
   var number = string.replace(/px/g,'');
   return parseInt(number, 10);
 }
+
 function extractPosition(element) {
   var style, position, i;
 
@@ -44,10 +58,15 @@ function extractPosition(element) {
       var transPosition = extractPositionFromTransform(style[transformProp]);
       position.x += transPosition.x;
       position.y += transPosition.y;
-      break;      
+      break;
     }
   }
   return position;
+}
+
+function sortItemsByPosition(view) {
+  var items = findItems(view);
+  return sortElementsByPosition(items);
 }
 
 function sortElementsByPosition (elements) {
@@ -79,7 +98,7 @@ function sortByPosition (a, b) {
 }
 
 function itemPositions(view) {
-  return Ember.A(view.$('.ember-list-item-view').toArray()).map(function(e) {
+  return Ember.A(findItems(view).toArray()).map(function(e) {
     return extractPosition(e);
   }).sort(sortByPosition);
 }
@@ -87,6 +106,9 @@ function itemPositions(view) {
 export {
   itemPositions,
   generateContent,
-  sortElementsByPosition,
   extractPosition,
-  compile };
+  compile,
+  findContainer,
+  findItems,
+  findVisibleItems,
+  sortItemsByPosition };

--- a/tests/unit/content-test.js
+++ b/tests/unit/content-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { test, moduleForComponent } from 'ember-qunit';
-import {generateContent, sortElementsByPosition} from '../helpers/helpers';
+import {generateContent, sortItemsByPosition, findItems, findContainer} from '../helpers/helpers';
 import template from '../templates/fixed-grid';
 
 var nItems = 100;
@@ -22,10 +22,10 @@ test("replacing the list content", function(assert) {
   });
 
   Ember.run(()=>{
-    assert.equal(this.$('.ember-list-item-view')
+    assert.equal(findItems(this)
       .filter(function(){ return $(this).css('display') !== 'none'; })
       .length, 1, "The rendered list was updated");
-    assert.equal(this.$('.ember-collection div:first').height(), itemHeight, "The scrollable view has the correct height");
+    assert.equal(findItems(this).height(), itemHeight, "The scrollable view has the correct height");
   });
 });
 
@@ -39,13 +39,13 @@ test("adding to the front of the list content", function(assert) {
     content.unshiftObject({name: "Item -1"});
   });
 
-  var positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+  var positionSorted = sortItemsByPosition(this);
   assert.equal(
     Ember.$(positionSorted[0]).text().trim(),
     "Item -1", "The item has been inserted in the list");
   var expectedRows = Math.ceil((nItems + 1) / (width / itemWidth));
   assert.equal(
-    this.$('.ember-collection div:first').height(),
+    findContainer(this).height(),
     expectedRows * itemHeight,
     "The scrollable view has the correct height");
 });
@@ -60,7 +60,7 @@ test("inserting in the middle of visible content", function(assert) {
     content.insertAt(2, {name: "Item 2'"});
   });
 
-  var positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+  var positionSorted = sortItemsByPosition(this);
   assert.equal(
     Ember.$(positionSorted[0]).text().trim(),
     "Item 1", "The item has been inserted in the list");
@@ -79,7 +79,7 @@ test("clearing the content", function(assert) {
     content.clear();
   });
 
-  assert.equal(this.$('.ember-list-item-view')
+  assert.equal(findItems(this)
     .filter(function(){ return $(this).css('display') !== 'none'; })
     .length, 0, "The rendered list does not contain any elements.");
 });
@@ -91,7 +91,7 @@ test("deleting the first element", function(assert) {
     this.setProperties({height, width, itemHeight, itemWidth, content});
   });
 
-  var positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+  var positionSorted = sortItemsByPosition(this);
   assert.equal(
     Ember.$(positionSorted[0]).text().trim(),
     "Item 1", "Item 1 has not been removed from the list.");
@@ -100,7 +100,7 @@ test("deleting the first element", function(assert) {
     content.removeAt(0);
   });
 
-  positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+  positionSorted = sortItemsByPosition(this);
   assert.equal(
     Ember.$(positionSorted[0]).text().trim(),
     "Item 2", "Item 1 has been remove from the list.");

--- a/tests/unit/fixed-grid-test.js
+++ b/tests/unit/fixed-grid-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { test, moduleForComponent } from 'ember-qunit';
-import { generateContent, sortElementsByPosition } from '../helpers/helpers';
+import { generateContent, sortItemsByPosition } from '../helpers/helpers';
 import template from '../templates/fixed-grid';
 
 moduleForComponent('ember-collection', 'display in fixed grid', {integration: true});
@@ -14,7 +14,8 @@ test('display 5 in 6', function(assert) {
     this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
   });
-  var positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+
+  var positionSorted = sortItemsByPosition(this);
 
   assert.equal(
     Ember.$(positionSorted[0]).text().trim(),

--- a/tests/unit/multi-height-list-view-test.js
+++ b/tests/unit/multi-height-list-view-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import {moduleForComponent} from 'ember-qunit';
-import {skip} from 'qunit';
-import {sortElementsByPosition} from '../helpers/helpers';
+import { moduleForComponent } from 'ember-qunit';
+import { skip } from 'qunit';
+import { sortItemsByPosition, findItems } from '../helpers/helpers';
 // import hbs from 'htmlbars-inline-precompile';
 
 // TODO: Remove these declarations. They're just there to keep JSHint happy.
@@ -75,8 +75,8 @@ skip("Correct height based on content", function(assert) {
 
   assert.equal(view.get('totalHeight'), 3350);
 
-  var positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
-  assert.equal(this.$('.ember-list-item-view').length, 4);
+  var positionSorted = sortItemsByPosition(this);
+  assert.equal(findItems(this).length, 4);
 
   assert.equal(Ember.$(positionSorted[0]).text(), "Meow says Andrew expected: cat === cat 1");
   assert.equal(Ember.$(positionSorted[1]).text(), "Meow says Bruce expected: cat === cat 3");
@@ -91,7 +91,7 @@ skip("Correct height based on content", function(assert) {
   ], 'went beyond scroll max via overscroll');
 
   Ember.run(view, 'scrollTo', 1000);
-  positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+  positionSorted = sortItemsByPosition(this);
 
   assert.equal(Ember.$(positionSorted[0]).text(), "Potato says Xbar expected: other === other 12");
   assert.equal(Ember.$(positionSorted[1]).text(), "Woof says Harry expected: dog === dog 13");
@@ -176,8 +176,8 @@ skip("Correct height based on view", function(assert) {
 
   assert.equal(view.get('totalHeight'), 3350);
 
-  var positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
-  assert.equal(this.$('.ember-list-item-view').length, 4);
+  var positionSorted = sortItemsByPosition(this);
+  assert.equal(findItems(this).length, 4);
 
   assert.equal(Ember.$(positionSorted[0]).text(), "Meow says Andrew expected: cat === cat 1");
   assert.equal(Ember.$(positionSorted[1]).text(), "Meow says Bruce expected: cat === cat 3");
@@ -192,7 +192,7 @@ skip("Correct height based on view", function(assert) {
   ], 'went beyond scroll max via overscroll');
 
   Ember.run(view, 'scrollTo', 1000);
-  positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+  positionSorted = sortItemsByPosition(this);
 
   assert.equal(Ember.$(positionSorted[0]).text(), "Potato says Xbar expected: other === other 12");
   assert.equal(Ember.$(positionSorted[1]).text(), "Woof says Harry expected: dog === dog 13");
@@ -269,8 +269,8 @@ skip("handle bindable rowHeight with multi-height (only fallback case)", functio
 
   this.render();
 
-  var positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
-  assert.equal(this.$('.ember-list-item-view').length, 4);
+  var positionSorted = sortItemsByPosition(this);
+  assert.equal(findItems(this).length, 4);
   assert.equal(view.get('totalHeight'), 3750);
 
   // expected
@@ -303,8 +303,8 @@ skip("handle bindable rowHeight with multi-height (only fallback case)", functio
 
   Ember.run(view, 'set', 'rowHeight', 200);
 
-  positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
-  assert.equal(this.$('.ember-list-item-view').length, 3);
+  positionSorted = sortItemsByPosition(this);
+  assert.equal(findItems(this).length, 3);
   assert.equal(view.get('totalHeight'), 5550);
 
   // expected

--- a/tests/unit/recycling-tests.js
+++ b/tests/unit/recycling-tests.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import {moduleForComponent} from 'ember-qunit';
-import {skip} from 'qunit';
-import {generateContent} from '../helpers/helpers';
+import { moduleForComponent } from 'ember-qunit';
+import { skip } from 'qunit';
+import { generateContent, findItems, findVisibleItems } from '../helpers/helpers';
 // import hbs from 'htmlbars-inline-precompile';
 
 // TODO: Remove these declarations. They're just there to keep JSHint happy.
@@ -62,7 +62,7 @@ skip("recycling complex views long list", function(assert){
   assert.equal(innerViewInsertionCount, 2, "expected number of innerView's didInsertElement");
   assert.equal(innerViewDestroyCount, 0, "expected number of innerView's didInsertElement");
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered");
 
   innerViewInsertionCount = 0;
   innerViewDestroyCount = 0;
@@ -71,7 +71,7 @@ skip("recycling complex views long list", function(assert){
     view.scrollTo(50);
   });
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered");
 
   assert.equal(innerViewInsertionCount, 1, "expected number of innerView's didInsertElement");
   assert.equal(innerViewDestroyCount, 1, "expected number of innerView's willDestroyElement");
@@ -86,7 +86,7 @@ skip("recycling complex views long list", function(assert){
     view.scrollTo(0);
   });
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered");
 
   assert.equal(innerViewInsertionCount, 1, "expected number of innerView's didInsertElement");
   assert.equal(innerViewDestroyCount, 1, "expected number of innerView's willDestroyElement");
@@ -149,14 +149,14 @@ skip("recycling complex views short list", function(assert){
   assert.equal(innerViewInsertionCount, 2, "expected number of innerView's didInsertElement (post-append)");
   assert.equal(innerViewDestroyCount, 0, "expected number of innerView's didInsertElement (post-append)");
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered");
 
   innerViewInsertionCount = 0;
   innerViewDestroyCount = 0;
 
   view.scrollTo(50);
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered (post-scroll to 50)");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered (post-scroll to 50)");
 
   assert.equal(innerViewInsertionCount, 0, "expected number of innerView's didInsertElement (post-scroll to 50)");
   assert.equal(innerViewDestroyCount, 0, "expected number of innerView's willDestroyElement (post-scroll to 50)");
@@ -169,7 +169,7 @@ skip("recycling complex views short list", function(assert){
 
   view.scrollTo(0);
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered (post-scroll to 0)");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered (post-scroll to 0)");
 
   assert.equal(innerViewInsertionCount, 0, "expected number of innerView's didInsertElement (post-scroll to 0)");
   assert.equal(innerViewDestroyCount, 0, "expected number of innerView's willDestroyElement (post-scroll to 0)");
@@ -251,7 +251,7 @@ skip("recycling complex views long list, with ReusableListItemView", function(as
   assert.equal(innerViewInsertionCount, 2, "expected number of innerView's didInsertElement (post-append)");
   assert.equal(innerViewDestroyCount, 0, "expected number of innerView's didInsertElement (post-append)");
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered");
 
   listItemViewInsertionCount = 0;
   listItemViewDestroyCount = 0;
@@ -260,7 +260,7 @@ skip("recycling complex views long list, with ReusableListItemView", function(as
 
   view.scrollTo(50);
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered (post-scroll to 50)");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered (post-scroll to 50)");
 
   assert.equal(listItemViewInsertionCount, 0, "expected number of listItemView's didInsertElement (post-scroll to 50)");
   assert.equal(listItemViewDestroyCount, 0, "expected number of listItemView's willDestroyElement (post-scroll to 50)");
@@ -274,7 +274,7 @@ skip("recycling complex views long list, with ReusableListItemView", function(as
 
   view.scrollTo(0);
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered (post-scroll to 0)");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered (post-scroll to 0)");
 
   assert.equal(listItemViewInsertionCount, 0, "expected number of listItemView's didInsertElement (post-scroll to 0)");
   assert.equal(listItemViewDestroyCount, 0, "expected number of listItemView's willDestroyElement (post-scroll to 0)");
@@ -354,7 +354,7 @@ skip("recycling complex views short list, with ReusableListItemView", function(a
   assert.equal(innerViewInsertionCount, 2, "expected number of innerView's didInsertElement (post-append)");
   assert.equal(innerViewDestroyCount, 0, "expected number of innerView's didInsertElement (post-append)");
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered");
 
   listItemViewInsertionCount = 0;
   listItemViewDestroyCount = 0;
@@ -363,7 +363,7 @@ skip("recycling complex views short list, with ReusableListItemView", function(a
 
   view.scrollTo(50);
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered (post-scroll to 50)");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered (post-scroll to 50)");
 
   assert.equal(listItemViewInsertionCount, 0, "expected number of listItemView's didInsertElement (post-scroll to 50)");
   assert.equal(listItemViewDestroyCount, 0, "expected number of listItemView's willDestroyElement (post-scroll to 50)");
@@ -377,7 +377,7 @@ skip("recycling complex views short list, with ReusableListItemView", function(a
 
   view.scrollTo(0);
 
-  assert.equal(this.$('.ember-list-item-view').length, 2, "The correct number of rows were rendered (post-scroll to 0)");
+  assert.equal(findItems(this).length, 2, "The correct number of rows were rendered (post-scroll to 0)");
 
   assert.equal(listItemViewInsertionCount, 0, "expected number of listItemView's didInsertElement (post-scroll to 0)");
   assert.equal(listItemViewDestroyCount, 0, "expected number of listItemView's willDestroyElement (post-scroll to 0)");
@@ -461,8 +461,8 @@ skip("recycling complex views with ReusableListItemView, handling empty slots at
   assert.equal(innerViewInsertionCount, 8, "expected number of innerView's didInsertElement (post-append)");
   assert.equal(innerViewDestroyCount, 0, "expected number of innerView's didInsertElement (post-append)");
 
-  assert.equal(this.$('.ember-list-item-view').length, 8, "The correct number of items were rendered (post-append)");
-  assert.equal(this.$('.ember-list-item-view:visible').length, 8, "The number of items that are not hidden with display:none (post-append)");
+  assert.equal(findItems(this).length, 8, "The correct number of items were rendered (post-append)");
+  assert.equal(findVisibleItems(this).length, 8, "The number of items that are not hidden with display:none (post-append)");
 
   listItemViewInsertionCount = 0;
   listItemViewDestroyCount = 0;
@@ -471,8 +471,8 @@ skip("recycling complex views with ReusableListItemView, handling empty slots at
 
   view.scrollTo(350);
 
-  assert.equal(this.$('.ember-list-item-view').length, 8, "The correct number of items were rendered (post-scroll to 350)");
-  assert.equal(this.$('.ember-list-item-view:visible').length, 8, "The number of items that are not hidden with display:none (post-scroll to 350)");
+  assert.equal(findItems(this).length, 8, "The correct number of items were rendered (post-scroll to 350)");
+  assert.equal(findVisibleItems(this).length, 8, "The number of items that are not hidden with display:none (post-scroll to 350)");
 
   assert.equal(listItemViewInsertionCount, 0, "expected number of listItemView's didInsertElement (post-scroll to 350)");
   assert.equal(listItemViewDestroyCount, 0, "expected number of listItemView's willDestroyElement (post-scroll to 350)");
@@ -488,12 +488,12 @@ skip("recycling complex views with ReusableListItemView, handling empty slots at
     view.set('width', 150);
   });
 
-  assert.equal(this.$('.ember-list-item-view').length, 12, "The correct number of items were rendered (post-expand to 3 columns)");
+  assert.equal(findItems(this).length, 12, "The correct number of items were rendered (post-expand to 3 columns)");
 
   assert.equal(listItemViewInsertionCount, 4, "expected number of listItemView's didInsertElement (post-expand to 3 columns)");
   assert.equal(listItemViewDestroyCount, 0, "expected number of listItemView's willDestroyElement (post-expand to 3 columns)");
   assert.equal(innerViewInsertionCount, 4, "expected number of innerView's didInsertElement (post-expand to 3 columns)");
   assert.equal(innerViewDestroyCount, 0, "expected number of innerView's willDestroyElement (post-expand to 3 columns)");
 
-  assert.equal(this.$('.ember-list-item-view:visible').length, 12, "The number of items that are not hidden with display:none (post-expand to 3 columns)");
+  assert.equal(findVisibleItems(this).length, 12, "The number of items that are not hidden with display:none (post-expand to 3 columns)");
 });

--- a/tests/unit/scroll-top-test.js
+++ b/tests/unit/scroll-top-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { test, moduleForComponent } from 'ember-qunit';
-import { generateContent, sortElementsByPosition } from '../helpers/helpers';
+import { generateContent, sortItemsByPosition } from '../helpers/helpers';
 import template from '../templates/fixed-grid';
 
 var content = generateContent(5);
@@ -16,7 +16,7 @@ test("base case", function(assert) {
     this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
   });
   assert.equal(this.$('.ember-collection').prop('scrollTop'), 0);
-  var positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+  var positionSorted = sortItemsByPosition(this);
   assert.equal(
     Ember.$(positionSorted[0]).text().trim(),
     "Item 1", "The first item has not been hidden");
@@ -33,7 +33,7 @@ test("scroll but within content length", function(assert){
 
   Ember.run(() => {
     this.render(template);
-    this.setProperties({ 
+    this.setProperties({
       width, height, itemWidth, itemHeight, content, offsetY });
   });
   assert.equal(
@@ -43,9 +43,9 @@ test("scroll but within content length", function(assert){
   });
   assert.equal(
     this.$('.ember-collection').prop('scrollTop'), 0, 'No scroll with wider list.');
-  var positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+  var positionSorted = sortItemsByPosition(this);
   assert.equal(
-    Ember.$(positionSorted[0]).text().trim(), 
+    Ember.$(positionSorted[0]).text().trim(),
     "Item 1", "The first item is not visible but in buffer.");
 });
 
@@ -55,16 +55,16 @@ test("scroll within content length, beyond buffer", function(assert){
 
   Ember.run(() => {
     this.render(template);
-    this.setProperties({ 
+    this.setProperties({
       width, height, itemWidth, itemHeight, offsetY,
       content: generateContent(10) });
   });
   Ember.run(()=>{ this.set('offsetY', 150);});
   assert.equal(
     this.$('.ember-collection').prop('scrollTop'), 150, 'scrolled to item 7');
-  var positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+  var positionSorted = sortItemsByPosition(this);
   assert.equal(
-    Ember.$(positionSorted[0]).text().trim(), 
+    Ember.$(positionSorted[0]).text().trim(),
     "", "The first 2 items have been dropped.");
 
   Ember.run(()=>{
@@ -72,9 +72,9 @@ test("scroll within content length, beyond buffer", function(assert){
   });
   assert.equal(
     this.$('.ember-collection').prop('scrollTop'), 50, 'Scrolled down one row.');
-  positionSorted = sortElementsByPosition(this.$('.ember-list-item-view'));
+  positionSorted = sortItemsByPosition(this);
   assert.equal(
-    Ember.$(positionSorted[0]).text().trim(), 
+    Ember.$(positionSorted[0]).text().trim(),
     "Item 1", "The first item is in buffer again.");
 });
 

--- a/tests/unit/total-height-test.js
+++ b/tests/unit/total-height-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { test, moduleForComponent } from 'ember-qunit';
-import { generateContent } from '../helpers/helpers';
+import { generateContent, findContainer } from '../helpers/helpers';
 import template from '../templates/fixed-grid';
 
 moduleForComponent('ember-collection', 'totalHeight', { integration: true });
@@ -14,7 +14,7 @@ test("single column", function(assert) {
     this.setProperties({ width, height, itemWidth, itemHeight, content });
   });
 
-  assert.equal(this.$('.ember-collection div:first').height(), 1000);
+  assert.equal(findContainer(this).height(), 1000);
 });
 
 test("even", function(assert) {
@@ -26,7 +26,7 @@ test("even", function(assert) {
     this.setProperties({ width, height, itemWidth, itemHeight, content });
   });
 
-  assert.equal(this.$('.ember-collection div:first').height(), 500);
+  assert.equal(findContainer(this).height(), 500);
 });
 
 test("odd", function(assert) {
@@ -38,5 +38,5 @@ test("odd", function(assert) {
     this.setProperties({ width, height, itemWidth, itemHeight, content });
   });
 
-  assert.equal(this.$('.ember-collection div:first').height(), 550);
+  assert.equal(findContainer(this).height(), 550);
 });


### PR DESCRIPTION
This is a work in progress, but wanted to get it up here to get feedback. This (again) has to use css selectors to reach into the structure to assert various things:

 - [x] Remove all references to ember-list-view-item
 - [x] Create helpers to reduce amount of :spaghetti: 
 - [x] Replace all selector usages with helpers