### PR TITLE
Abstract scrolling WIP

### DIFF
--- a/addon/components/ember-collection/template.hbs
+++ b/addon/components/ember-collection/template.hbs
@@ -1,5 +1,7 @@
-<div>
-  {{~#each cells as |cell|~}}
-    <div style={{{cell.style}}}>{{#unless cell.hidden}}{{yield cell.item cell.index }}{{/unless}}</div>
-  {{~/each~}}
-</div>
+{{#ember-native-scrollable content-size=_contentSize scroll-left=_scrollLeft scroll-top=_scrollTop scrollChange=(action "scrollChange") clientSizeChange=(action "clientSizeChange")}}
+  <div>
+    {{~#each _cells as |cell|~}}
+      <div style={{{cell.style}}}>{{#unless cell.hidden}}{{yield cell.item cell.index }}{{/unless}}</div>
+    {{~/each~}}
+  </div>
+{{/ember-native-scrollable}}

--- a/addon/components/ember-native-scrollable.js
+++ b/addon/components/ember-native-scrollable.js
@@ -1,0 +1,120 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  init() {
+    this._clientWidth = 0;
+    this._clientHeight = 0;
+    this._scrollLeft = 0;
+    this._scrollTop = 0;
+    this._animationFrame = undefined;
+    this._super();
+  },
+  didReceiveAttrs() {
+    this._contentSize = this.getAttr('content-size');
+    this._scrollLeft = this.getAttr('scroll-left');
+    this._scrollTop = this.getAttr('scroll-top');
+  },
+  didInsertElement() {
+    this.contentElement = this.element.firstElementChild;
+    this.applyStyle();
+    this.applyContentSize();
+    this.syncScrollFromAttr();
+    this.startScrollCheck();
+  },
+  didUpdate() {
+    this.applyContentSize();
+  },
+  willDestroyElement() {
+    this.cancelScrollCheck();
+    this.contentElement = undefined;
+  },
+  applyStyle() {
+    // TODO this should be auto when not using overflowScrolling
+    this.element.style.overflow = 'scroll';
+    this.element.style.webkitOverflowScrolling = 'touch';
+
+    // hack to force render buffer so outside doesn't repaint on scroll
+    this.element.style.webkitTransform = 'translate3d(0px, 0px, 0px) scale(1)';
+    this.element.style.mozTransform = 'translate3d(0px, 0px, 0px) scale(1)';
+    this.element.style.msTransform = 'translate3d(0px, 0px, 0px) scale(1)';
+    this.element.style.oTransform = 'translate3d(0px, 0px, 0px) scale(1)';
+    this.element.style.transform = 'translate3d(0px, 0px, 0px) scale(1)';
+
+    this.element.style.position = 'absolute';
+    this.element.style.left = 0;
+    this.element.style.top = 0;
+    this.element.style.bottom = 0;
+    this.element.style.right = 0;
+    this.element.style.boxSizing = 'border-box';
+  },
+  applyContentSize() {
+    this.contentElement.style.position = 'relative';
+    this.contentElement.style.width = this._contentSize.width + 'px';
+    this.contentElement.style.height = this._contentSize.height + 'px';
+  },
+  syncScrollFromAttr() {
+    if (this._scrollTop > 0) {
+      this.element.scrollTop = this._scrollTop;
+      this._scrollTop = this.element.scrollTop; // read it back in case our adjustment wasn't possible
+    }
+    if (this._scrollLeft > 0) {
+      this.element.scrollLeft = this._scrollLeft;
+      this._scrollLeft = this.element.scrollLeft;
+    }
+  },
+  startScrollCheck() {
+    const component = this;
+    function step() {
+      component.scrollCheck();
+      nextStep();
+    }
+    function nextStep() {
+      component._animationFrame = requestAnimationFrame(step);
+    }
+    nextStep();
+  },
+  cancelScrollCheck() {
+    if (this._animationFrame) {
+      cancelAnimationFrame(this._animationFrame);
+      this._animationFrame = undefined;
+    }
+  },
+  scrollCheck() {
+    let element = this.element;
+    let scrollLeft = element.scrollLeft;
+    let scrollTop = element.scrollTop;
+    let scrollChanged = false;
+    if (scrollLeft !== this._scrollLeft || scrollTop !== this._scrollTop) {
+      scrollChanged = true;
+      this._scrollLeft = scrollLeft;
+      this._scrollTop = scrollTop;
+    }
+
+    let clientWidth = element.clientWidth;
+    let clientHeight = element.clientHeight;
+    let clientSizeChanged = false;
+    if (clientWidth !== this._clientWidth || clientHeight !== this._clientHeight) {
+      clientSizeChanged = true;
+      console.debug('clientSizeChanged', clientWidth, clientHeight);
+      this._clientWidth = clientWidth;
+      this._clientHeight = clientHeight;
+    }
+
+    if (scrollChanged || clientSizeChanged) {
+      Ember.run(() => {
+        if (scrollChanged) {
+          this.sendScrollChange(scrollLeft, scrollTop);
+        }
+        if (clientSizeChanged) {
+          this.sendClientSizeChange(clientWidth, clientHeight);
+        }
+      });
+    }
+  },
+  sendScrollChange(scrollLeft, scrollTop) {
+    this.sendAction('scrollChange', { scrollLeft, scrollTop });
+  },
+  sendClientSizeChange(width, height) {
+    this.sendAction('clientSizeChange', { width, height });
+  }
+});

--- a/addon/layouts/grid.js
+++ b/addon/layouts/grid.js
@@ -6,14 +6,11 @@ export default class Grid
     this.bin = new Bin.FixedGrid(this, cellWidth, cellHeight);
   }
 
-  contentWidth(width) {
-    return width;
-  }
-
-  contentHeight(width) {
-    // width sic! the content height depends on visible width and
-    // number of items.
-    return this.bin.height(width);
+  contentSize(clientSize) {
+    return {
+      width: clientSize.width,
+      height: this.bin.height(clientSize.width)
+    };
   }
 
   indexAt(offsetX, offsetY, width, height) {

--- a/addon/layouts/mixed-grid.js
+++ b/addon/layouts/mixed-grid.js
@@ -6,20 +6,19 @@ export default class MixedGrid
     this.bin = new Bin.ShelfFirst(content, width);
   }
 
-  contentWidth(width /*,height*/) {
-    return width;
-  }
-
-  contentHeight() {
-    return this.bin.height();
+  contentSize(clientSize) {
+    return {
+      width: clientSize.width,
+      height: this.bin.height(clientSize.width)
+    };
   }
 
   indexAt(offsetX, offsetY, width, height) {
     return this.bin.visibleStartingIndex(offsetY, width, height);
   }
 
-  positionAt(index, width /*,height*/) {
-    return this.bin.position(index, width);
+  positionAt(index, width, height) {
+    return this.bin.position(index, width, height);
   }
 
   widthAt(index) {

--- a/app/components/ember-collection.js
+++ b/app/components/ember-collection.js
@@ -1,2 +1,1 @@
-import EmberCollection from 'ember-collection/components/ember-collection';
-export default EmberCollection;
+export { default } from 'ember-collection/components/ember-collection';

--- a/app/components/ember-native-scrollable.js
+++ b/app/components/ember-native-scrollable.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-collection/components/ember-native-scrollable';

--- a/tests/dummy/app/controllers/mixed.js
+++ b/tests/dummy/app/controllers/mixed.js
@@ -1,0 +1,2 @@
+import Ember from 'ember';
+export default Ember.Controller.extend({});

--- a/tests/dummy/app/helpers/size-to-style.js
+++ b/tests/dummy/app/helpers/size-to-style.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+export default Ember.Helper.helper(function ([width, height]) {
+  return Ember.String.htmlSafe(`position: relative; width: ${width}px; height: ${height}px;`);
+});

--- a/tests/dummy/app/templates/mixed.hbs
+++ b/tests/dummy/app/templates/mixed.hbs
@@ -1,5 +1,5 @@
-<div class="mixed">
-  {{#ember-collection items=model height=800 width=500 buffer=10 cell-layout=(mixed-grid-layout model) as |item index|}}
+<div class="mixed" style="position:relative;height:500px">
+  {{#ember-collection items=model estimated-height=800 estimated-width=500 buffer=10 cell-layout=(mixed-grid-layout model) as |item index|}}
     <div class="list-item">
       {{item.name}}
     </div>

--- a/tests/dummy/app/templates/simple.hbs
+++ b/tests/dummy/app/templates/simple.hbs
@@ -14,8 +14,8 @@ Item Width: {{itemWidth}}
 </p>
 <hr />
 
-<div class="simple-list">
-  {{#ember-collection items=model height=containerHeight width=containerWidth buffer=10 cell-layout=(fixed-grid-layout itemWidth itemHeight) as |item index|}}
+<div class="simple-list" style={{{concat 'position:relative;width:' containerWidth 'px;height:' containerHeight 'px;'}}}>
+  {{#ember-collection items=model estimated-height=containerHeight estimated-width=containerWidth buffer=10 cell-layout=(fixed-grid-layout itemWidth itemHeight) as |item index|}}
     <div class="list-item">
       {{item.name}}
     </div>

--- a/tests/index.html
+++ b/tests/index.html
@@ -16,6 +16,12 @@
 
     {{content-for 'head-footer'}}
     {{content-for 'test-head-footer'}}
+
+    <style type="text/css">
+    #ember-testing {
+        zoom: 1;
+    }
+    </style>
   </head>
   <body>
 

--- a/tests/templates/fixed-grid.js
+++ b/tests/templates/fixed-grid.js
@@ -1,13 +1,14 @@
 import hbs from 'htmlbars-inline-precompile';
 
-export default hbs`{{#ember-collection
+export default hbs`<div style={{size-to-style width height}}>{{#ember-collection
     items=content
     cell-layout=(fixed-grid-layout itemWidth itemHeight)
-    width=width
-    height=height
-    offset-x=offsetX
-    offset-y=offsetY
+    estimated-width=width
+    estimated-height=height
+    scroll-left=offsetX
+    scroll-top=offsetY
+    buffer=buffer
     class="ember-collection"
     as |item| ~}}
   <div class="list-item">{{item.name}}</div>
-{{~/ember-collection~}}`;
+{{~/ember-collection~}}</div>`;

--- a/tests/unit/content-test.js
+++ b/tests/unit/content-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { test, moduleForComponent } from 'ember-qunit';
-import { 
-  generateContent, sortItemsByPosition, findItems, findContainer, 
+import {
+  generateContent, sortItemsByPosition, findItems, findContainer,
   checkContent } from '../helpers/helpers';
 import template from '../templates/fixed-grid';
 
@@ -19,8 +19,8 @@ test("replacing the list content", function(assert) {
   var content = generateContent(nItems);
 
   Ember.run(()=>{
-    this.render(template);
     this.setProperties({height, width, itemHeight, itemWidth, content});
+    this.render(template);
     this.set('content', Ember.A([{name: 'The only item'}]));
   });
 
@@ -29,7 +29,7 @@ test("replacing the list content", function(assert) {
       .filter(function(){ return $(this).css('display') !== 'none'; })
       .length, 1, "The rendered list was updated");
 
-    assert.equal(findItems(this).height(), itemHeight, "The scrollable view has the correct height");
+    assert.equal(findItems(this).height(), itemHeight, "The items have the correct height");
     checkContent(this, assert, 0, 1);
   });
 });
@@ -38,8 +38,8 @@ test("adding to the front of the list content", function(assert) {
   var content = generateContent(nItems);
 
   Ember.run(()=>{
-    this.render(template);
     this.setProperties({height, width, itemHeight, itemWidth, content});
+    this.render(template);
   });
 
   Ember.run(function() {
@@ -64,8 +64,8 @@ test("inserting in the middle of visible content", function(assert) {
   var content = generateContent(nItems);
 
   Ember.run(()=>{
-    this.render(template);
     this.setProperties({height, width, itemHeight, itemWidth, content});
+    this.render(template);
   });
 
   Ember.run(function() {
@@ -73,7 +73,6 @@ test("inserting in the middle of visible content", function(assert) {
   });
 
   var positionSorted = sortItemsByPosition(this);
-
   assert.equal(
     Ember.$(positionSorted[0]).text().trim(),
     "Item 1", "The item has been inserted in the list");
@@ -89,8 +88,8 @@ test("clearing the content", function(assert) {
   var content = generateContent(nItems);
 
   Ember.run(()=>{
-    this.render(template);
     this.setProperties({height, width, itemHeight, itemWidth, content});
+    this.render(template);
   });
 
   Ember.run(function() {
@@ -106,8 +105,8 @@ test("deleting the first element", function(assert) {
   var content = generateContent(nItems);
 
   Ember.run(()=>{
-    this.render(template);
     this.setProperties({height, width, itemHeight, itemWidth, content});
+    this.render(template);
   });
 
   var positionSorted = sortItemsByPosition(this);

--- a/tests/unit/fixed-grid-test.js
+++ b/tests/unit/fixed-grid-test.js
@@ -13,10 +13,9 @@ test('display 5 in 6', function(assert) {
   var content = generateContent(5);
 
   Ember.run(() => {
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
+    this.render(template);
   });
-
   var positionSorted = sortItemsByPosition(this);
 
   assert.equal(

--- a/tests/unit/scroll-top-test.js
+++ b/tests/unit/scroll-top-test.js
@@ -1,7 +1,31 @@
+/* global requestAnimationFrame */
 import Ember from 'ember';
 import { test, moduleForComponent } from 'ember-qunit';
-import { generateContent, sortItemsByPosition, checkContent } from '../helpers/helpers';
+import { findScrollable, generateContent, sortItemsByPosition, checkContent } from '../helpers/helpers';
 import template from '../templates/fixed-grid';
+
+var RSVP = Ember.RSVP;
+
+var size;
+// lifted from antiscroll MIT license
+function scrollbarSize() {
+  if (size === undefined) {
+    var div = $(
+      '<div class="antiscroll-inner" style="width:50px;height:50px;overflow-y:scroll;' +
+      'position:absolute;top:-200px;left:-200px;"><div style="height:100px;width:100%"/>' +
+      '</div>'
+    );
+
+    $('body').append(div);
+    var w1 = $(div).innerWidth();
+    var w2 = $('div', div).innerWidth();
+    $(div).remove();
+
+    size = w1 - w2;
+  }
+
+  return size;
+}
 
 var content = generateContent(5);
 
@@ -14,11 +38,11 @@ test("base case", function(assert) {
   var offsetY = 0;
 
   Ember.run(() => {
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
+    this.render(template);
   });
 
-  assert.equal(this.$('.ember-collection').prop('scrollTop'), 0);
+  assert.equal(findScrollable(this).prop('scrollTop'), 0);
 
   var positionSorted = sortItemsByPosition(this);
 
@@ -30,89 +54,108 @@ test("base case", function(assert) {
     this.set('width', 150);
   });
 
-  assert.equal(this.$('.ember-collection').prop('scrollTop'), 0);
+  assert.equal(findScrollable(this).prop('scrollTop'), 0);
   checkContent(this, assert, 0, 5);
 });
 
 test("scroll but within content length", function(assert){
-  var width = 100, height = 100, itemWidth = 50, itemHeight = 50;
+  var width = 100+scrollbarSize(), height = 100+scrollbarSize(), itemWidth = 50, itemHeight = 50;
   var offsetY = 100;
 
   Ember.run(() => {
-    this.render(template);
     this.setProperties({
       width, height, itemWidth, itemHeight, content, offsetY });
+    this.render(template);
   });
 
   assert.equal(
-    this.$('.ember-collection').prop('scrollTop'), 50, 'Scrolled one row.');
+    findScrollable(this).prop('scrollTop'), 50, 'Scrolled one row.');
 
   Ember.run(()=>{
-    this.set('width', 150);
+    this.set('width', 150+scrollbarSize());
   });
 
-  assert.equal(
-    this.$('.ember-collection').prop('scrollTop'), 0, 'No scroll with wider list.');
+  return new RSVP.Promise(function (resolve) {
+    requestAnimationFrame(() => {
+      Ember.run(resolve);
+    });
+  }).then(() => {
+    assert.equal(
+      findScrollable(this).prop('scrollTop'), 0, 'No scroll with wider list.');
 
-  var positionSorted = sortItemsByPosition(this);
+    var positionSorted = sortItemsByPosition(this);
 
-  assert.equal(
-    Ember.$(positionSorted[0]).text().trim(),
-    "Item 1", "The first item is not visible but in buffer.");
-  checkContent(this, assert, 0, 5);
+    assert.equal(
+      Ember.$(positionSorted[0]).text().trim(),
+      "Item 1", "The first item is not visible but in buffer.");
+    checkContent(this, assert, 0, 5);
+  });
+
 });
 
 test("scroll within content length, beyond buffer", function(assert){
-  var width = 100, height = 100, itemWidth = 50, itemHeight = 50;
+  var width = 100+scrollbarSize(), height = 100+scrollbarSize(), itemWidth = 50, itemHeight = 50;
   var offsetY = 0;
 
   Ember.run(() => {
-    this.render(template);
     this.setProperties({
       width, height, itemWidth, itemHeight, offsetY,
+      buffer: 0,
       content: generateContent(10) });
+    this.render(template);
   });
 
-  Ember.run(()=>{ this.set('offsetY', 150);});
-  assert.equal(
-    this.$('.ember-collection').prop('scrollTop'), 150, 'scrolled to item 7');
+  findScrollable(this).prop('scrollTop', 150);
+  return new RSVP.Promise(function (resolve) {
+    requestAnimationFrame(() => {
+      Ember.run(resolve);
+    });
+  }).then(() => {
 
-  var positionSorted = sortItemsByPosition(this);
+    assert.equal(
+      findScrollable(this).prop('scrollTop'), 150, 'scrolled to item 7');
 
-  assert.equal(
-    Ember.$(positionSorted[0]).text().trim(),
-    "", "The first 2 items have been dropped.");
+    let positionSorted = sortItemsByPosition(this);
 
-  Ember.run(()=>{
-    this.set('width', 200);
+    assert.equal(
+      Ember.$(positionSorted[0]).text().trim(),
+      "", "The first 2 items have been dropped.");
+
+    Ember.run(()=>{
+      this.set('width', 200+scrollbarSize());
+    });
+    return new RSVP.Promise(function (resolve) {
+      requestAnimationFrame(() => {
+        Ember.run(resolve);
+      });
+    });
+  }).then(() => {
+    assert.equal(
+      findScrollable(this).prop('scrollTop'), 50, 'Scrolled down one row.');
+    let positionSorted = sortItemsByPosition(this, true);
+    console.log('positionSorted: ', positionSorted);
+    assert.equal(
+      Ember.$(positionSorted[0]).text().trim(),
+      "Item 5", "The fifth item is first rendered.");
+    checkContent(this, assert, 4, 5);
   });
-
-  assert.equal(
-    this.$('.ember-collection').prop('scrollTop'), 50, 'Scrolled down one row.');
-
-  positionSorted = sortItemsByPosition(this);
-
-  assert.equal(
-    Ember.$(positionSorted[0]).text().trim(),
-    "Item 1", "The first item is in buffer again.");
-  checkContent(this, assert, 0, 5);
 });
 
 test("scroll but beyond content length", function(assert) {
-  var width = 100, height = 500, itemWidth = 50, itemHeight = 50;
+  var width = 100+scrollbarSize(), height = 500+scrollbarSize(), itemWidth = 50, itemHeight = 50;
   var offsetY = 1000;
 
   Ember.run(() => {
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
+    this.render(template);
   });
 
-  assert.equal(this.$('.ember-collection').prop('scrollTop'), 0);
+  assert.equal(findScrollable(this).prop('scrollTop'), 0);
 
   Ember.run(() => {
-    this.set('width', 150);
+    this.set('width', 150+scrollbarSize());
   });
 
-  assert.equal(this.$('.ember-collection').prop('scrollTop'), 0);
+  assert.equal(findScrollable(this).prop('scrollTop'), 0);
   checkContent(this, assert, 0, 5);
 });

--- a/tests/unit/starting-index-test.js
+++ b/tests/unit/starting-index-test.js
@@ -12,8 +12,8 @@ test("base case", function(assert) {
   var content = generateContent(5);
 
   Ember.run(() => {
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content });
+    this.render(template);
   });
 
   assert.equal(this.get('startingIndex', 0));
@@ -25,8 +25,8 @@ test("scroll but within content length", function(assert) {
   var offsetY = 100;
 
   Ember.run(() => {
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
+    this.render(template);
   });
 
   assert.equal(this.get('startingIndex', 0));
@@ -38,8 +38,8 @@ test("scroll but beyond content length", function(assert) {
   var offsetY = 100;
 
   Ember.run(() => {
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
+    this.render(template);
   });
 
   assert.equal(this.get('startingIndex', 0));
@@ -51,8 +51,8 @@ test("larger list", function(assert) {
   var offsetY = 100;
 
   Ember.run(() => {
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
+    this.render(template);
   });
 
   assert.equal(this.get('startingIndex', 28));
@@ -64,8 +64,8 @@ test("larger list (2)", function(assert) {
   var offsetY = 100;
 
   Ember.run(() => {
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
+    this.render(template);
   });
 
   assert.equal(this.get('startingIndex', 1));

--- a/tests/unit/total-height-test.js
+++ b/tests/unit/total-height-test.js
@@ -12,8 +12,8 @@ test("single column", function(assert) {
   var content = generateContent(20);
 
   Ember.run(()=>{
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content });
+    this.render(template);
   });
 
   assert.equal(findContainer(this).height(), 1000);
@@ -24,8 +24,8 @@ test("even", function(assert) {
   var content = generateContent(20);
 
   Ember.run(()=>{
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content });
+    this.render(template);
   });
 
   assert.equal(findContainer(this).height(), 500);
@@ -36,8 +36,8 @@ test("odd", function(assert) {
   var content = generateContent(21);
 
   Ember.run(()=>{
-    this.render(template);
     this.setProperties({ width, height, itemWidth, itemHeight, content });
+    this.render(template);
   });
 
   assert.equal(findContainer(this).height(), 550);


### PR DESCRIPTION
This PR extracts a "scrollable" component in for better separation of responsibilities and to prepare for alternate implementations of scrolling (JS-based virtual scrolling to support UIWebView usage in particular).

Several changes will be required for users of master once this is merged:

1) Update your CSS to account for an additional div. Structure is now:

```
div.ember-collection
    div (from ember-native-scrollable)
        div (wraps all content)
            divs (cells)
```

2) Use CSS to specify height/width of div surrounding ember-collection. ember-collection now detects and adjusts it's size based on it's container. The `width` and `height` attributes are not longer used. For initial render (including fast-boot future), you should supply `estimated-width` and `estimated-height` attributes.

3) `offset-x` and `offset-y` attributes have been renamed to `scroll-left` and `scroll-top`

4) If you have custom layouts, the expected API has changed. You should replace your `contentWidth` and `contentHeight` methods with a `contentSize` method that accepts and clientSize object with `width` and `height` properties, and returns an object with the same property names representing the total content size. 