### PR TITLE
Format style can now take a string value for width. Eg. '100%'

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -18,7 +18,8 @@ class Cell {
 function formatStyle(pos, width, height) {
   let css = 'position:absolute;top:0;left:0;';
   css += translateCSS(pos.x, pos.y);
-  css += 'width:' + width + 'px;height:' + height + 'px;';
+  if(typeof width !== 'string') width += 'px';
+  css += 'width:' + width + ';height:' + height + 'px;';
   return css;
 }
 


### PR DESCRIPTION
I added this because I wanted to pass width="100%" to the component. This commit optionally lets the list view occupy a non pixel width.