### PR TITLE
Add visibleStartingIndex to build InfiniteScroll

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -33,6 +33,7 @@ export default Ember.Component.extend({
     this._items = undefined;
     this._scrollLeft = undefined;
     this._scrollTop = undefined;
+    this._scrollIndex = undefined;
     this._clientWidth = undefined;
     this._clientHeight = undefined;
     this._contentSize = undefined;
@@ -206,16 +207,37 @@ export default Ember.Component.extend({
     }
     this._cellMap = cellMap;
   },
+  getScrollIndex(scrollLeft, scrollTop) {
+    let itemWidth  = this._cellLayout.bin._elementWidth;
+    let itemHeight = this._cellLayout.bin._elementHeight;
+    let containerWidth  = this._clientWidth;
+    let containerHeight = this._clientHeight;
+
+    let itemsPerRow = Math.floor(containerWidth / itemWidth);
+    let itemsPerCol = Math.floor(containerHeight / itemHeight);
+
+    let colIndex = Math.ceil(scrollLeft / itemWidth);
+    let rowIndex = Math.ceil(scrollTop  / itemHeight);
+
+    let visibleItems = itemsPerRow * itemsPerCol;
+    let scrolledItems = (rowIndex * itemsPerRow) + (colIndex * itemsPerCol) - (rowIndex * colIndex);
+
+    return  scrolledItems + visibleItems - 1;
+  },
+
   actions: {
     scrollChange(scrollLeft, scrollTop) {
+      let scrollIndex = this.getScrollIndex(scrollLeft, scrollTop);
       if (this._scrollChange) {
         // console.log('ember-collection sendAction scroll-change', scrollTop);
-        this.sendAction('scroll-change', scrollLeft, scrollTop);
+        this.sendAction('scroll-change', scrollLeft, scrollTop, scrollIndex);
       } else {
         if (scrollLeft !== this._scrollLeft ||
-            scrollTop !== this._scrollTop) {
+            scrollTop !== this._scrollTop ||
+            scrollIndex !== this._scrollIndex) {
           set(this, '_scrollLeft', scrollLeft);
           set(this, '_scrollTop', scrollTop);
+          set(this, '_scrollIndex', scrollIndex);
           needsRevalidate(this);
         }
       }

--- a/tests/dummy/app/controllers/scroll-position.js
+++ b/tests/dummy/app/controllers/scroll-position.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   itemWidth: 100,
   itemHeight: 100,
+  scrollIndex: 0,
   containerWidth: 315,
   containerHeight: 600,
   scrollLeft: 0,
@@ -20,7 +21,7 @@ export default Ember.Controller.extend({
     makeSquare: function() {
       this.setProperties({
         itemWidth: 100,
-        itemHeight: 100,
+        itemHeight: 100
       });
     },
 
@@ -45,10 +46,11 @@ export default Ember.Controller.extend({
       });
     },
 
-    scrollChange: function(scrollLeft, scrollTop){
+    scrollChange: function(scrollLeft, scrollTop, scrollIndex){
       this.setProperties({
         scrollLeft: scrollLeft,
-        scrollTop: scrollTop
+        scrollTop: scrollTop,
+        scrollIndex: scrollIndex
       });
     }
   }

--- a/tests/dummy/app/controllers/scroll-position.js
+++ b/tests/dummy/app/controllers/scroll-position.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   itemWidth: 100,
   itemHeight: 100,
-  scrollIndex: 0,
+  startingVisibleIndex: 0,
   containerWidth: 315,
   containerHeight: 600,
   scrollLeft: 0,
@@ -46,11 +46,11 @@ export default Ember.Controller.extend({
       });
     },
 
-    scrollChange: function(scrollLeft, scrollTop, scrollIndex){
+    scrollChange: function(scrollLeft, scrollTop, startingVisibleIndex){
       this.setProperties({
         scrollLeft: scrollLeft,
         scrollTop: scrollTop,
-        scrollIndex: scrollIndex
+        startingVisibleIndex: startingVisibleIndex
       });
     }
   }

--- a/tests/templates/fixed-grid-scroll-change.js
+++ b/tests/templates/fixed-grid-scroll-change.js
@@ -1,0 +1,15 @@
+import hbs from 'htmlbars-inline-precompile';
+
+export default hbs`<div style={{size-to-style width height}}>{{#ember-collection
+    items=content
+    cell-layout=(fixed-grid-layout itemWidth itemHeight)
+    estimated-width=width
+    estimated-height=height
+    scroll-left=offsetX
+    scroll-top=offsetY
+    scroll-change="scrollChange"
+    buffer=buffer
+    class="ember-collection"
+    as |item| ~}}
+  <div class="list-item">{{item.name}}</div>
+{{~/ember-collection~}}</div>`;

--- a/tests/unit/starting-index-test.js
+++ b/tests/unit/starting-index-test.js
@@ -1,13 +1,19 @@
 import Ember from 'ember';
 import { test, moduleForComponent } from 'ember-qunit';
 import { generateContent } from '../helpers/helpers';
-import template from '../templates/fixed-grid';
+import template from '../templates/fixed-grid-scroll-change';
 
 moduleForComponent('ember-collection', 'startingIndex', {
-  integration: true
+  integration: true,
+  beforeEach: function() {
+    this.startingIndex = 0;
+    this.on('scrollChange', (scrollTop, scrollLeft, scrollIndex) => {
+      this.startingIndex = scrollIndex;
+    });
+  }
 });
 
-test("base case", function(assert) {
+test("when not scrolling through content", function(assert) {
   var width = 100, height = 500, itemWidth = 50, itemHeight = 50;
   var content = generateContent(5);
 
@@ -16,10 +22,10 @@ test("base case", function(assert) {
     this.render(template);
   });
 
-  assert.equal(this.get('startingIndex', 0));
+  assert.equal(this.startingIndex, 0);
 });
 
-test("scroll but within content length", function(assert) {
+test("when content does not fill the container", function(assert) {
   var width = 100, height = 500, itemWidth = 50, itemHeight = 50;
   var content = generateContent(5);
   var offsetY = 100;
@@ -29,10 +35,10 @@ test("scroll but within content length", function(assert) {
     this.render(template);
   });
 
-  assert.equal(this.get('startingIndex', 0));
+  assert.equal(this.startingIndex, 0);
 });
 
-test("scroll but beyond content length", function(assert) {
+test("when content fills exactly the container", function(assert) {
   var width = 100, height = 500, itemWidth = 50, itemHeight = 50;
   var content = generateContent(20);
   var offsetY = 100;
@@ -42,23 +48,10 @@ test("scroll but beyond content length", function(assert) {
     this.render(template);
   });
 
-  assert.equal(this.get('startingIndex', 0));
+  assert.equal(this.startingIndex, 0);
 });
 
-test("larger list", function(assert) {
-  var width = 100, height = 500, itemWidth = 50, itemHeight = 50;
-  var content = generateContent(50);
-  var offsetY = 100;
-
-  Ember.run(() => {
-    this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
-    this.render(template);
-  });
-
-  assert.equal(this.get('startingIndex', 28));
-});
-
-test("larger list (2)", function(assert) {
+test("when scrolling past the first row", function(assert) {
   var width = 100, height = 200, itemWidth = 50, itemHeight = 100;
   var content = generateContent(50);
   var offsetY = 100;
@@ -68,5 +61,18 @@ test("larger list (2)", function(assert) {
     this.render(template);
   });
 
-  assert.equal(this.get('startingIndex', 1));
+  assert.equal(this.startingIndex, 2);
+});
+
+test("when scrolling past the first two rows", function(assert) {
+  var width = 100, height = 500, itemWidth = 50, itemHeight = 50;
+  var content = generateContent(50);
+  var offsetY = 100;
+
+  Ember.run(() => {
+    this.setProperties({ width, height, itemWidth, itemHeight, content, offsetY });
+    this.render(template);
+  });
+
+  assert.equal(this.startingIndex, 4);
 });


### PR DESCRIPTION
### Infinite-Scroll
**The goal of this PR is to be able to implement an Infinite-Scroll container using `ember-collection`.**

In order to have infinite-scroll, the container must be able to indicate when it is nearing the end of the present content. The `visibleStartingIndex` attribute on a `scroll-change` action indicates we are viewing `content[visibleStartingIndex]` at the top left most corner of the container. We are then able to make decisions whether to load / unload records from the Data Store.

* *Fixed starting-index-test*

> Previous tests in `starting-index-test.js` did not actually test anything and were in fact broken. 
``` js
// Present non-test
assert.equal( this.get('startingIndex', 0) ) // evaluates to assert.equal(undefined) => true
```
``` js
// Replaced by working test
assert.equal( this.startingIndex, 0 )
```

* *Add visibleStartingIndex*

> Add this attribute to `ember-collection.js` and `dummy/scroll-poisition.js` 