### PR TITLE
Wrapping items in Ember.Array to provide uniform access to data

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -87,7 +87,7 @@ export default Ember.Component.extend({
         this._items.removeObserver('[]', this, this._needsRevalidate);
       }
 
-      this.set('_items', items);
+      this.set('_items', Ember.A(items));
 
       if (items && items.addObserver) {
         items.addObserver('[]', this, this._needsRevalidate);
@@ -152,7 +152,7 @@ export default Ember.Component.extend({
 
     for (i=0; i<count; i++) {
       itemIndex = index+i;
-      itemKey = decodeEachKey(items[itemIndex], '@identity');
+      itemKey = decodeEachKey(items.objectAt(itemIndex), '@identity');
       if (priorMap) {
         cell = priorMap[itemKey];
       }
@@ -175,7 +175,7 @@ export default Ember.Component.extend({
       if (!cellMap[cell.key]) {
         if (newItems.length) {
           itemIndex = newItems.pop();
-          itemKey = decodeEachKey(items[itemIndex], '@identity');
+          itemKey = decodeEachKey(items.objectAt(itemIndex), '@identity');
           pos = this._cellLayout.positionAt(itemIndex, this._clientWidth, this._clientHeight);
           width = this._cellLayout.widthAt(itemIndex, this._clientWidth, this._clientHeight);
           height = this._cellLayout.heightAt(itemIndex, this._clientWidth, this._clientHeight);
@@ -183,7 +183,7 @@ export default Ember.Component.extend({
           set(cell, 'style', style);
           set(cell, 'key', itemKey);
           set(cell, 'index', itemIndex);
-          set(cell, 'item', items[itemIndex]);
+          set(cell, 'item', items.objectAt(itemIndex));
           set(cell, 'hidden', false);
           cellMap[itemKey] = cell;
         } else {
@@ -195,12 +195,12 @@ export default Ember.Component.extend({
 
     for (i=0; i<newItems.length; i++) {
       itemIndex = newItems[i];
-      itemKey = decodeEachKey(items[itemIndex], '@identity');
+      itemKey = decodeEachKey(items.objectAt(itemIndex), '@identity');
       pos = this._cellLayout.positionAt(itemIndex, this._clientWidth, this._clientHeight);
       width = this._cellLayout.widthAt(itemIndex, this._clientWidth, this._clientHeight);
       height = this._cellLayout.heightAt(itemIndex, this._clientWidth, this._clientHeight);
       style = formatStyle(pos, width, height);
-      cell = new Cell(itemKey, items[itemIndex], itemIndex, style);
+      cell = new Cell(itemKey, items.objectAt(itemIndex), itemIndex, style);
       cellMap[itemKey] = cell;
       this._cells.pushObject(cell);
     }


### PR DESCRIPTION
I was seeing the same problem reported in #55.  In my case, I am passing in the results from my model hook.  This results in an error when trying to access a property in the component used in the ember collection.

For example, using this:
```
  {{#ember-collection
    items=results
    height=500
    width=800
    cell-layout=(fixed-grid-layout 800 50) as |item index|
  }}
    {{my-component foo=item}}
  {{/ember-collection}}
```

I would get an error when trying to access data from the passed in item:
```
this.getAttr('foo').get('bar') --> throws something like  'get is not a function of `undefined`'
```

The problem is that updateItems gets 'undefined' when accessing item[itemIndex].  The result list has the correct length, but no data.