### PR TITLE
automated deploys to github pages

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,0 +1,28 @@
+/* jshint node: true */
+
+module.exports = function(deployTarget) {
+  var ENV = {
+    build: {}
+    // include other plugin configuration that applies to all deploy targets here
+  };
+
+  if (deployTarget === 'development') {
+    ENV.build.environment = 'development';
+    // configure other plugins for development deploy target here
+  }
+
+  if (deployTarget === 'staging') {
+    ENV.build.environment = 'production';
+    // configure other plugins for staging deploy target here
+  }
+
+  if (deployTarget === 'production') {
+    ENV.build.environment = 'production';
+    // configure other plugins for production deploy target here
+  }
+
+  // Note: if you need to build some configuration asynchronously, you can return
+  // a promise that resolves with the ENV object instead of returning the
+  // ENV object synchronously.
+  return ENV;
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "devDependencies": {
     "ember-cli": "1.13.8",
     "ember-cli-dependency-checker": "^1.0.1",
+    "ember-cli-deploy": "0.5.1",
+    "ember-cli-deploy-build": "0.1.0",
+    "ember-cli-deploy-git": "0.1.0",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.0",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -44,7 +44,8 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
+    ENV.baseURL = '/ember-collection';
+    ENV.locationType = 'hash';
   }
 
   return ENV;


### PR DESCRIPTION
This lets us deploy the demo to GitHub Pages with a single command.

Required first-time setup: create a `gh-pages` branch with

    git branch --orphan gh-pages
    git commit --allow-empty
    git push -u origin gh-pages

After that, anyone with commit privleges to this repo can deploy on demand with `ember deploy production` and view the app at http://emberjs.github.io/ember-collection/