### PR TITLE
Delegate to layout for calculating style

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from './ember-collection/template';
-import { translateCSS } from '../utils/translate';
 import needsRevalidate from '../utils/needs-revalidate';
 var decodeEachKey = Ember.__loader.require('ember-htmlbars/utils/decode-each-key')['default'];
 const { get, set } = Ember;
@@ -13,13 +12,6 @@ class Cell {
     this.index = index;
     this.style = style;
   }
-}
-
-function formatStyle(pos, width, height) {
-  let css = 'position:absolute;top:0;left:0;';
-  css += translateCSS(pos.x, pos.y);
-  css += 'width:' + width + 'px;height:' + height + 'px;';
-  return css;
 }
 
 export default Ember.Component.extend({
@@ -155,7 +147,7 @@ export default Ember.Component.extend({
     index -= bufferBefore;
     count += bufferBefore;
     count = Math.min(count + this._buffer, get(items, 'length') - index);
-    var i, pos, width, height, style, itemIndex, itemKey, cell;
+    var i, style, itemIndex, itemKey, cell;
 
     var newItems = [];
 
@@ -166,10 +158,7 @@ export default Ember.Component.extend({
         cell = priorMap[itemKey];
       }
       if (cell) {
-        pos = this._cellLayout.positionAt(itemIndex, this._clientWidth, this._clientHeight);
-        width = this._cellLayout.widthAt(itemIndex, this._clientWidth, this._clientHeight);
-        height = this._cellLayout.heightAt(itemIndex, this._clientWidth, this._clientHeight);
-        style = formatStyle(pos, width, height);
+        style = this._cellLayout.formatItemStyle(itemIndex, this._clientWidth, this._clientHeight);
         set(cell, 'style', style);
         set(cell, 'hidden', false);
         set(cell, 'key', itemKey);
@@ -186,10 +175,7 @@ export default Ember.Component.extend({
           itemIndex = newItems.pop();
           let item = items.objectAt(itemIndex);
           itemKey = decodeEachKey(item, '@identity');
-          pos = this._cellLayout.positionAt(itemIndex, this._clientWidth, this._clientHeight);
-          width = this._cellLayout.widthAt(itemIndex, this._clientWidth, this._clientHeight);
-          height = this._cellLayout.heightAt(itemIndex, this._clientWidth, this._clientHeight);
-          style = formatStyle(pos, width, height);
+          style = this._cellLayout.formatItemStyle(itemIndex, this._clientWidth, this._clientHeight);
           set(cell, 'style', style);
           set(cell, 'key', itemKey);
           set(cell, 'index', itemIndex);
@@ -207,10 +193,7 @@ export default Ember.Component.extend({
       itemIndex = newItems[i];
       let item = items.objectAt(itemIndex);
       itemKey = decodeEachKey(item, '@identity');
-      pos = this._cellLayout.positionAt(itemIndex, this._clientWidth, this._clientHeight);
-      width = this._cellLayout.widthAt(itemIndex, this._clientWidth, this._clientHeight);
-      height = this._cellLayout.heightAt(itemIndex, this._clientWidth, this._clientHeight);
-      style = formatStyle(pos, width, height);
+      style = this._cellLayout.formatItemStyle(itemIndex, this._clientWidth, this._clientHeight);
       cell = new Cell(itemKey, item, itemIndex, style);
       cellMap[itemKey] = cell;
       this._cells.pushObject(cell);

--- a/addon/layouts/grid.js
+++ b/addon/layouts/grid.js
@@ -1,4 +1,5 @@
 import FixedGrid from 'layout-bin-packer/fixed-grid';
+import {formatPixelStyle} from '../utils/style-generators';
 
 export default class Grid
 {
@@ -36,5 +37,12 @@ export default class Grid
 
   maxScroll(width, height) {
     return this.bin.maxContentOffset(width, height);
+  }
+  
+  formatItemStyle(itemIndex, clientWidth, clientHeight) {
+    let pos = this.positionAt(itemIndex, clientWidth, clientHeight);
+    let width = this.widthAt(itemIndex, clientWidth, clientHeight);
+    let height = this.heightAt(itemIndex, clientWidth, clientHeight);
+    return formatPixelStyle(pos, width, height);
   }
 }

--- a/addon/layouts/mixed-grid.js
+++ b/addon/layouts/mixed-grid.js
@@ -1,4 +1,5 @@
 import ShelfFirst from 'layout-bin-packer/shelf-first';
+import {formatPixelStyle} from '../utils/style-generators';
 
 export default class MixedGrid
 {
@@ -33,7 +34,15 @@ export default class MixedGrid
   count(offsetX, offsetY, width, height) {
     return this.bin.numberVisibleWithin(offsetY, width, height, true);
   }
+  
   maxScroll(width, height) {
     return this.bin.maxContentOffset(width, height);
+  }
+  
+  formatItemStyle(itemIndex, clientWidth, clientHeight) {
+    let pos = this.positionAt(itemIndex, clientWidth, clientHeight);
+    let width = this.widthAt(itemIndex, clientWidth, clientHeight);
+    let height = this.heightAt(itemIndex, clientWidth, clientHeight);
+    return formatPixelStyle(pos, width, height);
   }
 }

--- a/addon/layouts/percentage-columns.js
+++ b/addon/layouts/percentage-columns.js
@@ -1,0 +1,69 @@
+import ShelfFirst from 'layout-bin-packer/shelf-first';
+import {formatPercentageStyle} from '../utils/style-generators';
+import Ember from 'ember';
+
+export default class MixedGrid
+{
+  // How this layout works is by creating a fake grid that is as wide as the number of columns.
+  // Each item's width is set to be 1px. The ShelfFirst lays out everything according to this fake grid.
+  // When ember-collection asks for the style in formatItemStyle we pull the percent property to use as the width
+  constructor(content, columns, height) {
+    let total = columns.reduce(function(a, b) {
+        return a+b;
+    });
+    Ember.assert('All columns must total less than 100 ' + total, total <= 100);
+    let positions = [];
+    var ci = 0;
+    for (var i = 0; i < content.length; i++) {
+        positions.push({
+            width: 1,
+            height: height,
+            percent: columns[ci]
+        });
+        
+        ci++;
+        
+        if (ci >= columns.length) {
+            ci = 0;
+        }
+    }
+    this.positions = positions;
+    this.bin = new ShelfFirst(positions, columns.length);
+  }
+
+  contentSize(clientWidth/*, clientHeight*/) {
+    let size = {
+      width: clientWidth,
+      height: this.bin.height(100)
+    };
+    return size;
+  }
+
+  indexAt(offsetX, offsetY, width, height) {
+    return this.bin.visibleStartingIndex(offsetY, 100, height);
+  }
+
+  positionAt(index, width, height) {
+    return this.bin.position(index, 100, height);
+  }
+
+  widthAt(index) {
+    return this.bin.widthAtIndex(index);
+  }
+
+  heightAt(index) {
+    return this.bin.heightAtIndex(index);
+  }
+
+  count(offsetX, offsetY, width, height) {
+    return this.bin.numberVisibleWithin(offsetY, 100, height, true);
+  }
+ 
+  formatItemStyle(itemIndex, clientWidth, clientHeight) {
+    let pos = this.positionAt(itemIndex, 100, clientHeight);
+    let width = this.positions[itemIndex].percent;
+    let height = this.heightAt(itemIndex, 100, clientHeight);
+    let x = Math.floor((pos.x / 100) * clientWidth);
+    return formatPercentageStyle({x:x, y:pos.y}, width, height);
+  }
+}

--- a/addon/utils/style-generators.js
+++ b/addon/utils/style-generators.js
@@ -1,0 +1,15 @@
+import { translateCSS } from './translate';
+
+export function formatPixelStyle(pos, width, height) {
+  let css = 'position:absolute;top:0;left:0;';
+  css += translateCSS(pos.x, pos.y);
+  css += 'width:' + width + 'px;height:' + height + 'px;';
+  return css;
+}
+
+export function formatPercentageStyle(pos, width, height) {
+  let css = 'position:absolute;top:0;left:0;';
+  css += translateCSS(pos.x, pos.y);
+  css += 'width:' + width + '%;height:' + height + 'px;';
+  return css;
+}

--- a/app/helpers/percentage-columns-layout.js
+++ b/app/helpers/percentage-columns-layout.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import PercentageColumns from 'ember-collection/layouts/percentage-columns';
+
+export default Ember.Helper.helper(function (params, hash) {
+  return new PercentageColumns(params[0], params[1], params[2]);
+});

--- a/tests/dummy/app/controllers/percentages.js
+++ b/tests/dummy/app/controllers/percentages.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+export default Ember.Controller.extend({
+  columns: Ember.computed(function() {
+    return [20, 60, 20];
+  }),
+  
+  actions: {
+    changeColumn: function(col) {
+      switch (col) {
+        case 1:
+          this.set('columns', [25, 50, 25]);
+          break;
+        case 2:
+          this.set('columns', [20, 20, 40, 20]);
+          break;
+        case 3:
+          this.set('columns', [33, 33, 33]);
+          break;
+        case 4:
+          this.set('columns', [50, 50]);
+          break;
+        case 5:
+          this.set('columns', [100]);
+          break;
+        default:
+          this.set('columns', [50, 50]);
+          break;
+        }
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,7 @@ Router.map(function() {
   this.route('simple');
   this.route('scroll-position');
   this.route('mixed');
+  this.route('percentages');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/percentages.js
+++ b/tests/dummy/app/routes/percentages.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import makeModel from '../utils/make-model';
+
+export default Ember.Route.extend({
+  model: makeModel()
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -14,6 +14,7 @@
         {{#link-to 'index' tagName='li' href=false}} {{link-to 'Home' 'index'}} {{/link-to}}
         {{#link-to 'simple' tagName='li' href=false}} {{link-to 'Fixed Grid' 'simple'}} {{/link-to}}
         {{#link-to 'mixed' tagName='li' href=false}} {{link-to 'Mixed Grid' 'mixed'}} {{/link-to}}
+        {{#link-to 'percentages' tagName='li' href=false}} {{link-to 'Percentages' 'percentages'}}{{/link-to}}
         {{#link-to 'scroll-position' tagName='li' href=false}} {{link-to 'Scroll Position' 'scroll-position'}}{{/link-to}}
         </ul>
     </div><!--/.navbar-collapse -->

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -4,20 +4,25 @@
 </div>
 
 <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-3">
         <h2>Fixed Grid Layout</h2>
         <p>Use the <code>fixed-grid-layout</code> when all items are the same size. The width and height of each item are bound as is the width and height of the container. Ember collection will re-layout items when any of these items change.</p>
         <p>{{link-to 'Demo' 'simple' class="btn btn-default"}}</p>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <h2>Mixed Grid Layout</h2>
         <p>Use the <code>mixed-grid-layout</code> when items can be a different size. The collection being itterated over is passed to the <code>mixed-grid-layout</code> helper. Each item in the collection must provide a <code>width</code> and <code>height</code> property of the item.</p>
         <p>{{link-to 'Demo' 'mixed' class="btn btn-default"}}</p>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <h2>Scroll Position</h2>
         <p>Use the <code>scroll-top</code> and <code>scroll-left</code> attributes to programtically scroll to a specific location in the collection. This can also be used to set an initial scroll position.</p>
         <p>{{link-to 'Demo' 'scroll-position' class="btn btn-default"}}</p>
+    </div>
+    <div class="col-md-3">
+        <h2>Percentage Columns</h2>
+        <p>Use the <code>percentage-columns-layout</code> to render a fixed number of columns that are sized using percentages. The <code>columns</code> paramter should be an array of integers that add to 100.</p>
+        <p>{{link-to 'Demo' 'percentages' class="btn btn-default"}}</p>
     </div>
 </div>
  

--- a/tests/dummy/app/templates/percentages.hbs
+++ b/tests/dummy/app/templates/percentages.hbs
@@ -1,0 +1,13 @@
+<button {{action 'changeColumn' 1}}>25-50-25</button>
+<button {{action 'changeColumn' 2}}>20-20-40-20</button>
+<button {{action 'changeColumn' 3}}>33-33-33</button>
+<button {{action 'changeColumn' 4}}>50-50</button>
+<button {{action 'changeColumn' 5}}>100</button>
+<hr />
+<div class="mixed" style="position:relative;height:500px;">
+  {{#ember-collection items=model estimated-height=800 estimated-width=1000 buffer=10 cell-layout=(percentage-columns-layout model columns 50) as |item index|}}
+    <div class="list-item">
+      {{item.name}}
+    </div>
+  {{/ember-collection}}
+</div>

--- a/tests/templates/percentage.js
+++ b/tests/templates/percentage.js
@@ -1,0 +1,14 @@
+import hbs from 'htmlbars-inline-precompile';
+
+export default hbs`<div style={{size-to-style width height}}>{{#ember-collection
+    items=content
+    cell-layout=(percentage-columns-layout content columns itemHeight)
+    estimated-width=width
+    estimated-height=height
+    scroll-left=offsetX
+    scroll-top=offsetY
+    buffer=buffer
+    class="ember-collection"
+    as |item| ~}}
+  <div class="list-item">{{item.name}}</div>
+{{~/ember-collection~}}</div>`;

--- a/tests/unit/layout-test.js
+++ b/tests/unit/layout-test.js
@@ -1,0 +1,52 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import { test, moduleForComponent } from 'ember-qunit';
+import { generateContent } from '../helpers/helpers';
+
+var nItems = 5;
+var itemWidth = 100;
+var itemHeight = 40;
+var width = 500;
+var height = 400;
+var columns = [25, 50, 15, 10];
+
+moduleForComponent('ember-collection', 'Basic layout tests', {
+  integration: true
+});
+
+test("ember-collection calls formatItemStyle", function(assert) {
+  var content = generateContent(nItems);
+  var callCount = 0;
+  var fakeLayout = {
+      indexAt: function() { return 0; },
+      count: function() { return nItems; },
+      contentSize: function() {
+          return {width, height};
+      },
+      formatItemStyle: function() {
+          callCount++;
+      }
+  };
+  
+  var template = hbs`<div style={{size-to-style width height}}>{{#ember-collection
+    items=content
+    cell-layout=fakeLayout
+    estimated-width=width
+    estimated-height=height
+    scroll-left=offsetX
+    scroll-top=offsetY
+    buffer=buffer
+    class="ember-collection"
+    as |item| ~}}
+  <div class="list-item">{{item.name}}</div>
+{{~/ember-collection~}}</div>`;
+  
+  Ember.run(()=>{
+    this.setProperties({height, width, itemHeight, itemWidth, content, columns, fakeLayout});
+    this.render(template);
+  });
+
+  Ember.run(()=>{
+    assert.equal(callCount, nItems, 'formatItemStyle is called for each rendered item');
+  });
+});

--- a/tests/unit/percentage-layout-test.js
+++ b/tests/unit/percentage-layout-test.js
@@ -1,0 +1,75 @@
+import Ember from 'ember';
+import { test, moduleForComponent } from 'ember-qunit';
+import {
+  generateContent, sortItemsByPosition } from '../helpers/helpers';
+import template from '../templates/percentage';
+
+var nItems = 100;
+var itemWidth = 100;
+var itemHeight = 40;
+var width = 500;
+var height = 400;
+var columns = [25, 50, 15, 10];
+
+moduleForComponent('ember-collection', 'percentage layout', {
+  integration: true
+});
+
+test("cells have correct width", function(assert) {
+  var content = generateContent(nItems);
+
+  Ember.run(()=>{
+    this.setProperties({height, width, itemHeight, itemWidth, content, columns});
+    this.render(template);
+  });
+
+  Ember.run(()=>{
+    var items = sortItemsByPosition(this);
+    
+    assert.equal(items[0].style.width, '25%', 'First Row, First column is 25%');
+    assert.equal(items[1].style.width, '50%', 'First Row, Second column is 50%');
+    assert.equal(items[2].style.width, '15%', 'First Row, Third column is 15%');
+    assert.equal(items[3].style.width, '10%', 'First Row, Fourth column is 10%');
+    
+    assert.equal(items[4].style.width, '25%', 'Second Row, First column is 25%');
+    assert.equal(items[5].style.width, '50%', 'Second Row, Second column is 50%');
+    assert.equal(items[6].style.width, '15%', 'Second Row, Third column is 15%');
+    assert.equal(items[7].style.width, '10%', 'Second Row, Fourth column is 10%');
+    
+    assert.equal(items.height(), itemHeight, "The items have the correct height");
+  });
+});
+
+test("columns can use decimals", function(assert) {
+  columns = [33.333, 66.666];
+  var content = generateContent(nItems);
+  
+  Ember.run(()=>{
+    this.setProperties({height, width, itemHeight, itemWidth, content, columns});
+    this.render(template);
+  });
+
+  Ember.run(()=>{
+    var items = sortItemsByPosition(this);
+    
+    assert.equal(items[0].style.width, '33.333%', 'First Row, First column is 33.333%');
+    assert.equal(items[1].style.width, '66.666%', 'First Row, Second column is 66.666%');
+    assert.equal(items[2].style.width, '33.333%', 'Second Row, First column is 33.333%');
+    assert.equal(items[3].style.width, '66.666%', 'Second Row, Second column is 66.666%');
+    
+    
+    assert.equal(items.height(), itemHeight, "The items have the correct height");
+  });
+});
+
+test("Asserts when columns are larger than 100", function(assert) {
+  columns = [99, 10];
+  var content = generateContent(nItems);
+  
+  assert.throws(function() {
+    Ember.run(()=>{
+      this.setProperties({height, width, itemHeight, itemWidth, content, columns});
+      this.render(template);
+    });
+  });
+});


### PR DESCRIPTION
This commit adds a method moves responsibility of generating css for a cell to the layout. This allows for layouts / positioning that are based on percentages rather than exact pixels.

To demonstrate how this works a new `percentage-columns-layout` is added that takes `items` `columns` and `itemHeight` as paramters where `columns` is an array of integers that adds to `100`. The layout then uses the `ShelfFirst` bin packer to position the items based on the percentages and calculates CSS that uses those percentages.

All the built in layouts use style generators that were moved into the `utils/style-generators`.

I think there is room for improvment on naming things, and the layout I included could use an assertion to make sure the columns actually add up to 100, but I wanted to get this out there to make sure the approach is sound.