### PR TITLE
Fix percentage-columns-layout

### DIFF
--- a/addon/layouts/percentage-columns.js
+++ b/addon/layouts/percentage-columns.js
@@ -4,19 +4,21 @@ import Ember from 'ember';
 
 export default class MixedGrid
 {
-  // How this layout works is by creating a fake grid that is as wide as the number of columns.
-  // Each item's width is set to be 1px. The ShelfFirst lays out everything according to this fake grid.
-  // When ember-collection asks for the style in formatItemStyle we pull the percent property to use as the width
-  constructor(content, columns, height) {
+  // How this layout works is by creating a fake grid that is 100px wide.
+  // Each item's width is set to be the size of the column. The ShelfFirst lays out everything according to this fake grid.
+  // When ember-collection asks for the style in formatItemStyle we pull the percent property to use as the width.
+  constructor(itemCount, columns, height) {
     let total = columns.reduce(function(a, b) {
         return a+b;
     });
-    Ember.assert('All columns must total less than 100 ' + total, total <= 100);
+    // Assert that the columns add up to 100. We don't want to infoce that they are EXACTLY 100 in case the user wants to use percentages.
+    // for example [33.333, 66.666]
+    Ember.assert('All columns must total 100 ' + total, total > 99 && total <= 100 );
     let positions = [];
     var ci = 0;
-    for (var i = 0; i < content.length; i++) {
+    for (var i = 0; i < itemCount; i++) {
         positions.push({
-            width: 1,
+            width: columns[ci],
             height: height,
             percent: columns[ci]
         });
@@ -28,7 +30,7 @@ export default class MixedGrid
         }
     }
     this.positions = positions;
-    this.bin = new ShelfFirst(positions, columns.length);
+    this.bin = new ShelfFirst(positions, 100);
   }
 
   contentSize(clientWidth/*, clientHeight*/) {

--- a/tests/dummy/app/templates/percentages.hbs
+++ b/tests/dummy/app/templates/percentages.hbs
@@ -5,7 +5,7 @@
 <button {{action 'changeColumn' 5}}>100</button>
 <hr />
 <div class="mixed" style="position:relative;height:500px;">
-  {{#ember-collection items=model estimated-height=800 estimated-width=1000 buffer=10 cell-layout=(percentage-columns-layout model columns 50) as |item index|}}
+  {{#ember-collection items=model estimated-height=800 estimated-width=1000 buffer=10 cell-layout=(percentage-columns-layout model.length columns 50) as |item index|}}
     <div class="list-item">
       {{item.name}}
     </div>

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -27,7 +27,14 @@ function findVisibleItems(context) {
 }
 
 function extractPosition(element) {
-  return element.getBoundingClientRect();
+    let parentRect = element.parentElement.getBoundingClientRect();
+    let elementRect = element.getBoundingClientRect();
+    return {
+        left: elementRect.left - parentRect.left,
+        top: elementRect.top - parentRect.top,
+        width: elementRect.width,
+        height: elementRect.height
+    };
 }
 
 function sortItemsByPosition(view, visibleOnly) {

--- a/tests/templates/percentage.js
+++ b/tests/templates/percentage.js
@@ -2,7 +2,7 @@ import hbs from 'htmlbars-inline-precompile';
 
 export default hbs`<div style={{size-to-style width height}}>{{#ember-collection
     items=content
-    cell-layout=(percentage-columns-layout content columns itemHeight)
+    cell-layout=(percentage-columns-layout content.length columns itemHeight)
     estimated-width=width
     estimated-height=height
     scroll-left=offsetX


### PR DESCRIPTION
Looks like a made a silly change that the tests didn't catch when first doing the percentage-columns-layout. This fixes that so the layout works properly. I also improved the tests so that it will catch it. The tests now check the top / left as well as the width property for the rendered items.

While I was in the code I changed a design decision that was bothering me. Instead of having to pass an array with the same number of items as the content to the layout, you just need to pass the number of items.

Finally I made the assert for the size of the columns more strict, since using a set of columns that were under 100 could cause the items to not fit into rows as desired. I fixed the tests that make sure we assert properly.