### PR TITLE
Remove template compiler from built assets.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,13 +6,5 @@ module.exports = function(defaults) {
     // Add options here
   });
 
-  /*
-    This build file specifes the options for the dummy test app of this
-    addon, located in `/tests/dummy`
-    This build file does *not* influence how the addon or the app using it
-    behave. You most likely want to be modifying `./index.js` or app's build file
-  */
-  app.import('bower_components/ember/ember-template-compiler.js');
-
   return app.toTree();
 };


### PR DESCRIPTION
We do not currently need this, and there are better ways of doing this that do not involve compiling templates in the browser (i.e.  `htmlbars-inline-precompiler`).