### PR TITLE
[WIP] Generate Twiddlish compatibleish fileish.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,10 +1,16 @@
 /* global require, module */
+var path = require('path');
 var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
+var BabelTranspiler = require('broccoli-babel-transpiler');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
+var Concat = require('broccoli-concat');
 
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     // Add options here
   });
+
 
   /*
     This build file specifes the options for the dummy test app of this
@@ -14,5 +20,35 @@ module.exports = function(defaults) {
   */
   app.import('bower_components/ember/ember-template-compiler.js');
 
-  return app.toTree();
+  var addonTree = new Funnel('addon', {
+    destDir: '/ember-collection'
+  });
+  var appTree = new Funnel('app', {
+    destDir: 'demo-app'
+  });
+  var layoutBinPackerPath = path.join(path.dirname(require.resolve('layout-bin-packer')), '..', 'lib', 'layout-bin-packer');
+  var layoutBinPackerTree = new Funnel(layoutBinPackerPath, {
+    destDir: '/layout-bin-packer'
+  });
+  var emberCollectionTemplateTree = new Concat(addonTree, {
+    inputFiles: ['ember-collection/components/ember-collection/template.hbs'],
+    header: 'export default Ember.HTMLBars.compile(`',
+    footer: '`)',
+    outputFile: 'ember-collection/components/ember-collection/template.js'
+  });
+
+  var mergedTrees = new MergeTrees([appTree, emberCollectionTemplateTree, addonTree, layoutBinPackerTree]);
+
+  var transpiledTree = new BabelTranspiler(mergedTrees, {
+    loose: true,
+    moduleIds: true,
+    modules: 'amdStrict'
+  });
+
+  var concattedTree = new Concat(transpiledTree, {
+    inputFiles: ['**/*.js'],
+    outputFile: '/twiddly-file.js'
+  });
+
+  return app.toTree(concattedTree);
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "author": "Erik Bryn, Yapp Inc., and contributors.",
   "license": "MIT",
   "devDependencies": {
+    "broccoli-babel-transpiler": "^5.5.0",
+    "broccoli-concat": "^2.1.0",
+    "broccoli-funnel": "^1.0.1",
+    "broccoli-merge-trees": "^1.1.1",
     "ember-cli": "^2.3.0-beta.1",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-deploy": "0.5.1",


### PR DESCRIPTION
This is an initial WIP to generate a `dist/twiddly-file.js` that could be uploaded to S3 and consumed by ember-twiddle.com demos.

Example demo (still requires a few hacks in ember-twiddle itself):

https://ember-twiddle.com/4556826aac0e7b2a60ef?numColumns=1&openFiles=application.template.hbs%2C

A @raytiley & @rwjblue production.
