### PR TITLE
WIP - Hack to preserve cell order

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -196,8 +196,16 @@ export default Ember.Component.extend({
       style = this._cellLayout.formatItemStyle(itemIndex, this._clientWidth, this._clientHeight);
       cell = new Cell(itemKey, item, itemIndex, style);
       cellMap[itemKey] = cell;
-      this._cells.pushObject(cell);
     }
+    
+    // hack to keep things in the correct order
+    var cells = [];
+    for (i=0; i < count; i++) {
+      itemIndex = index+i;
+      itemKey = decodeEachKey(items.objectAt(itemIndex), '@identity');
+      cells.push(cellMap[itemKey]);
+    }
+    set(this, '_cells', cells);
     this._cellMap = cellMap;
   },
   actions: {

--- a/tests/dummy/app/templates/percentages.hbs
+++ b/tests/dummy/app/templates/percentages.hbs
@@ -6,7 +6,7 @@
 <hr />
 <div class="mixed" style="position:relative;height:500px;">
   {{#ember-collection items=model estimated-height=800 estimated-width=1000 buffer=10 cell-layout=(percentage-columns-layout model.length columns 50) as |item index|}}
-    <div class="list-item">
+    <div class="list-item" tabindex=0>
       {{item.name}}
     </div>
   {{/ember-collection}}


### PR DESCRIPTION
This is a spike to fix issues #97, and #72.

Would like to get feedback from @krisselden and or @stefanpenner  about the approach.

Basically should we go through extra logic to keep the `_cells` array stable and just rearrange the items in it, or can we just build a new array and replace `_cells`.

Once an approach is decided on I can work on a more complete implementation and tests.