### PR TITLE
[Performance] Always render a consistent number of elements

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -143,10 +143,19 @@ export default Ember.Component.extend({
     var index = this._cellLayout.indexAt(this._scrollLeft, this._scrollTop, this._clientWidth, this._clientHeight);
     var count = this._cellLayout.count(this._scrollLeft, this._scrollTop, this._clientWidth, this._clientHeight);
     var items = this._items;
+
+    // Ideally we want to keep a constant number of elements in the list at all
+    // times to avoid initial renders during scroll.  To avoid inserting a
+    // bunch of elements as soon as the list is scrolled for the first time, we
+    // take the unused bufferBefore amount and add that to the bufferAfter.
+
     var bufferBefore = Math.min(index, this._buffer);
+    var unusedBufferBefore = this._buffer - bufferBefore;
+    var bufferAfter = this._buffer + unusedBufferBefore;
     index -= bufferBefore;
     count += bufferBefore;
-    count = Math.min(count + this._buffer, get(items, 'length') - index);
+    count = Math.min(count + bufferAfter, get(items, 'length') - index);
+
     var i, style, itemIndex, itemKey, cell;
 
     var newItems = [];


### PR DESCRIPTION
TLDR: this modification improves performance when an ember-collection is scrolled for the first time after being rendered.

Forgive my loose terminology below - let me know if I am not making sense.

Assume a browser displays a vertically scrolling `ember-collection` that has 20 elements on screen and has a buffer value set to 5.  Currently, when this collection first renders, it will "initial-render" 20 elements on screen and an additional 5 elements off the bottom of the screen.  As soon as the user scrolls 5 elements down, it will have to "initial-render" an additional 5 elements off the top of the screen.  The other 25 elements that are already render will be "recycle-rendered" which is much faster.  The rendering of these 5 new elements can result in noticeable lag when the user first scrolls in a collection consisting of complex applications.  

In my use case, "initial render" of an element takes about ~20ms whereas "recycle-render" takes about ~3ms.  That 5 x ~20ms when scrolling results in choppy scrolling.  Scrolling is much smoother with this change in place.  I'm not really sure how I can quantify this more empirically.

I am submitting this for feedback before I do the work to fix the broken unit tests.  If there is support I will go ahead and get it ready for merge.  It may also make sense to implement the corresponding behaviour when starting at the end of the collection - though obviously this is more of an edge case.