### PR TITLE
Allow string width for percentage-columns

### DIFF
--- a/addon/layouts/percentage-columns.js
+++ b/addon/layouts/percentage-columns.js
@@ -8,6 +8,12 @@ export default class MixedGrid
   // Each item's width is set to be the size of the column. The ShelfFirst lays out everything according to this fake grid.
   // When ember-collection asks for the style in formatItemStyle we pull the percent property to use as the width.
   constructor(itemCount, columns, height) {
+    if (Ember.typeOf(columns) === 'string') {
+      columns = Ember.String.w(columns).map(function(column) {
+        return parseInt(column);
+      });
+    }
+    
     let total = columns.reduce(function(a, b) {
         return a+b;
     });


### PR DESCRIPTION
most of the time we won't declare the width of percentage-columns in targetObject. This way its possible to use string to

```
{{#ember-collection items=model estimated-height=800 estimated-width=1000 buffer=10 cell-layout=(percentage-columns-layout model.length "75 25" 50) as |item index|}}
                <div class="item">
                  {{item.title}}
                </div>
            {{/ember-collection}}
```