### PR TITLE
Fix for preserving cell order

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -189,7 +189,7 @@ export default Ember.Component.extend({
       }
     }
 
-    for (i=0; i<newItems.length; i++) {
+    for (i=newItems.length-1; i>-1; i--) {
       itemIndex = newItems[i];
       let item = items.objectAt(itemIndex);
       itemKey = decodeEachKey(item, '@identity');


### PR DESCRIPTION
The problems with cell order is occurring when ember-collection pushes new items in reversed order. This is a small fix for the problem. This will fix issue #111. It might fix #72, which I'm not sure, since I haven't tested.