### PR TITLE
Prevent `didInitAttrs` deprecation.

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -46,10 +46,8 @@ export default Ember.Component.extend({
     //   2. Set a property on `this` that is both not in the
     //      initial attrs hash and not on the prototype.
     this._super();
-    this.updateAttrs();
-  },
 
-  updateAttrs() {
+    // initialize from passed in attrs
     let buffer = this.getAttr('buffer'); // getIntAttr('buffer', 5)
     this._buffer = (typeof buffer === 'number') ? buffer : 5;
     this._scrollLeft = this.getAttr('scroll-left') | 0;

--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -46,9 +46,10 @@ export default Ember.Component.extend({
     //   2. Set a property on `this` that is both not in the
     //      initial attrs hash and not on the prototype.
     this._super();
+    this.updateAttrs();
   },
 
-  didInitAttrs() {
+  updateAttrs() {
     let buffer = this.getAttr('buffer'); // getIntAttr('buffer', 5)
     this._buffer = (typeof buffer === 'number') ? buffer : 5;
     this._scrollLeft = this.getAttr('scroll-left') | 0;


### PR DESCRIPTION
Slight tweak of https://github.com/emberjs/ember-collection/pull/120.

Closes #120.