### PR TITLE
If the contentSize is not known after the ember-native-collection is

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -46,9 +46,7 @@ export default Ember.Component.extend({
     //   2. Set a property on `this` that is both not in the
     //      initial attrs hash and not on the prototype.
     this._super();
-  },
 
-  didInitAttrs() {
     let buffer = this.getAttr('buffer'); // getIntAttr('buffer', 5)
     this._buffer = (typeof buffer === 'number') ? buffer : 5;
     this._scrollLeft = this.getAttr('scroll-left') | 0;
@@ -210,6 +208,12 @@ export default Ember.Component.extend({
   },
 
   actions: {
+    contentSizeUnknown(clientWidth, clientHeight){
+      set(this, '_clientWidth', clientWidth);
+      set(this, '_clientHeight', clientHeight);
+      this.updateContentSize();
+      return this.get('_contentSize');
+    },
     scrollChange(scrollLeft, scrollTop) {
       if (this._scrollChange) {
         // console.log('ember-collection sendAction scroll-change', scrollTop);

--- a/addon/components/ember-collection/template.hbs
+++ b/addon/components/ember-collection/template.hbs
@@ -1,4 +1,4 @@
-{{#ember-native-scrollable content-size=_contentSize scroll-left=_scrollLeft scroll-top=_scrollTop scrollChange=(action "scrollChange") clientSizeChange=(action "clientSizeChange")}}
+{{#ember-native-scrollable content-size=_contentSize scroll-left=_scrollLeft scroll-top=_scrollTop scrollChange=(action "scrollChange") clientSizeChange=(action "clientSizeChange") contentSizeUnknown=(action "contentSizeUnknown")}}
   <div>
     {{~#each _cells as |cell|~}}
       <div style={{{cell.style}}}>{{yield cell.item cell.index }}</div>

--- a/addon/components/ember-native-scrollable.js
+++ b/addon/components/ember-native-scrollable.js
@@ -20,6 +20,9 @@ export default Ember.Component.extend({
   },
   didInsertElement() {
     this.contentElement = this.element.firstElementChild;
+    if (this._contentSize.width === 0 && this._contentSize.height === 0) {
+      this._contentSize = this.contentSizeUnknown(this.element.clientWidth, this.element.clientHeight);
+    }
     this.applyStyle();
     this.applyContentSize();
     this.syncScrollFromAttr();


### PR DESCRIPTION
inserted into the DOM, then retrieve it from the layout
fixes issue #140 