### PR TITLE
Don't keep references to cells not in the 'items' colltection

### DIFF
--- a/addon/components/ember-collection.js
+++ b/addon/components/ember-collection.js
@@ -172,6 +172,7 @@ export default Ember.Component.extend({
       }
     }
 
+    var cellsToDelete = [];
     for (i=0; i<this._cells.length; i++) {
       cell = this._cells[i];
       if (!cellMap[cell.key]) {
@@ -187,11 +188,11 @@ export default Ember.Component.extend({
           set(cell, 'hidden', false);
           cellMap[itemKey] = cell;
         } else {
-          set(cell, 'hidden', true);
-          set(cell, 'style', 'height: 0; display: none;');
+          cellsToDelete.push(cell);
         }
       }
     }
+    this._cells.removeObjects(cellsToDelete);
 
     for (i=0; i<newItems.length; i++) {
       itemIndex = newItems[i];


### PR DESCRIPTION
If some items (that are currently visible)  are removed from the
‘items’ collection, then they are still referenced in the _cells
property. So they are still in the DOM (display: none). 
If afterwards these removed items are destroyed (item.destroy) and a re-rendering
(e.g.: change of screen size) occurs. Then this result in an error:
Assertion Failed: Cannot call writableTag after the object is destroyed.

This pull request removes all cells that are not in the items
collection.