### PR TITLE
Removed ember-try from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
-    "ember-try": "^0.2.0",
     "exists-sync": "0.0.3",
     "loader.js": "^4.0.0",
     "mkdirp": "^0.5.1"


### PR DESCRIPTION
Fixed deprecation warning:
DEPRECATION: ember-try is now included with ember-cli. Including it in your package.json is unnecessary.