### PR TITLE
[BREAKING] Bump minimum Node version to 4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/emberjs/ember-collection",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "author": "Erik Bryn, Yapp Inc., and contributors.",
   "license": "MIT",


### PR DESCRIPTION
Several of our subdependencies don't support Node 0.12 anymore, so we should properly signal that for ourself too.