### PR TITLE
Upgrade `layout-bin-packer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "^2.0.1",
-    "layout-bin-packer": "^1.2.0"
+    "layout-bin-packer": "^1.4.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,7 +2120,7 @@ electron-to-chromium@^1.3.24:
   version "1.3.27"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
 
-ember-cli-babel@^5.1.5, ember-cli-babel@^5.2.4:
+ember-cli-babel@^5.1.5:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -4117,11 +4117,11 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-layout-bin-packer@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/layout-bin-packer/-/layout-bin-packer-1.3.0.tgz#6f232f67db7606b2a405f39ae7197f2931a26c0c"
+layout-bin-packer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/layout-bin-packer/-/layout-bin-packer-1.4.0.tgz#4115a8e0089ee2a3ff53386ca70fdc16e8b95e07"
   dependencies:
-    ember-cli-babel "^5.2.4"
+    ember-cli-babel "^6.8.2"
 
 lazy-cache@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
In the process of trying to remove the `ember-cli-babel@5` deprecations, I ran into `layout-bin-packer` surfacing it. `1.4.0` was just published that removes the deprecation warning, so this bumps to that version to resolve the problem for people with the latest version of `ember-collection`.